### PR TITLE
update markdown-it-emoji dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,46 @@
 {
   "name": "markdown-emoji",
   "version": "0.0.9",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "markdown-emoji",
+      "version": "0.0.9",
+      "license": "MIT",
+      "dependencies": {
+        "markdown-it-emoji": "^2.0.0"
+      },
+      "devDependencies": {
+        "@types/vscode": "^1.33.0"
+      },
+      "engines": {
+        "vscode": "^1.15.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
+      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+      "dev": true
+    },
+    "node_modules/markdown-it-emoji": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
+    }
+  },
   "dependencies": {
     "@types/vscode": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-      "integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
+      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
       "dev": true
     },
     "markdown-it-emoji": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
-      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.0.tgz",
+      "integrity": "sha512-39j7/9vP/CPCKbEI44oV8yoPJTpvfeReTn/COgRhSpNrjWF3PfP/JUxxB0hxV6ynOY8KH8Y8aX9NMDdo6z+6YQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "@types/vscode": "^1.33.0"
   },
   "dependencies": {
-    "markdown-it-emoji": "^1.4.0"
+    "markdown-it-emoji": "^2.0.0"
   }
 }


### PR DESCRIPTION
Update the `markdown-it-emoji` dependency to the most current version, `2.0.0`.  This pulls in recent emoji additions which address some of the concerns in issue #5. 

